### PR TITLE
Add Xenon Headlights Color Sync

### DIFF
--- a/Client/Scripts/Networking/Receive.cs
+++ b/Client/Scripts/Networking/Receive.cs
@@ -349,6 +349,7 @@ namespace RageCoop.Client
                 v.RadioStation = packet.RadioStation;
                 v.LicensePlate = packet.LicensePlate;
                 v.Livery = packet.Livery;
+                v.HeadlightColor = packet.HeadlightColor;
                 v.ExtrasMask = packet.ExtrasMask;
             }
             v.SetLastSynced(full);

--- a/Client/Scripts/Networking/Send.cs
+++ b/Client/Scripts/Networking/Send.cs
@@ -136,6 +136,7 @@ namespace RageCoop.Client
                 packet.LockStatus = veh.LockStatus;
                 packet.LicensePlate = Call<string>(GET_VEHICLE_NUMBER_PLATE_TEXT, veh);
                 packet.Livery = Call<int>(GET_VEHICLE_LIVERY, veh);
+                packet.HeadlightColor = (byte)Call<int>(GET_VEHICLE_XENON_LIGHT_COLOR_INDEX, veh);
                 packet.ExtrasMask = v.GetVehicleExtras();
                 packet.RadioStation = v.MainVehicle == LastV
                     ? Util.GetPlayerRadioIndex() : byte.MaxValue;

--- a/Client/Scripts/Sync/Entities/Vehicle/SyncedVehicle.Variables.cs
+++ b/Client/Scripts/Sync/Entities/Vehicle/SyncedVehicle.Variables.cs
@@ -30,6 +30,7 @@ namespace RageCoop.Client
         internal byte RadioStation = 255;
         internal string LicensePlate { get; set; }
         internal int Livery { get; set; } = -1;
+        internal byte HeadlightColor { get; set; } = 255;
         internal VehicleDataFlags Flags { get; set; }
         internal ushort ExtrasMask;
 
@@ -74,6 +75,7 @@ namespace RageCoop.Client
         private bool _lastHornActive;
         private bool _lastTransformed;
         private int _lastLivery = -1;
+        private byte _lastHeadlightColor = 255;
         private Vector3 _predictedPosition;
         #endregion
 

--- a/Client/Scripts/Sync/Entities/Vehicle/SyncedVehicle.cs
+++ b/Client/Scripts/Sync/Entities/Vehicle/SyncedVehicle.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using GTA;
 using GTA.Math;
 using GTA.Native;
+using GTA.UI;
 using RageCoop.Core;
 using static ICSharpCode.SharpZipLib.Zip.ExtendedUnixData;
 
@@ -151,6 +152,11 @@ namespace RageCoop.Client
                     _lastLivery = Livery;
                 }
 
+                if (_lastHeadlightColor != HeadlightColor)
+                {
+                    Call(SET_VEHICLE_XENON_LIGHT_COLOR_INDEX, MainVehicle.Handle, HeadlightColor);
+                    _lastHeadlightColor = HeadlightColor;
+                }
                 MainVehicle.SetDamageModel(DamageModel);
 
                 if (MainVehicle.Handle == V?.Handle && Util.GetPlayerRadioIndex() != RadioStation)

--- a/Core/Packets/VehicleSync.cs
+++ b/Core/Packets/VehicleSync.cs
@@ -100,6 +100,8 @@ namespace RageCoop.Core
 
                     m.Write((byte)(Livery + 1));
 
+                    m.Write(HeadlightColor);
+
                     m.Write(ExtrasMask);
                 }
             }
@@ -173,6 +175,8 @@ namespace RageCoop.Core
 
                     Livery = m.ReadByte() - 1;
 
+                    HeadlightColor = m.ReadByte();
+
                     ExtrasMask = m.ReadUInt16();
                 }
 
@@ -198,7 +202,7 @@ namespace RageCoop.Core
             public VehicleLockStatus LockStatus { get; set; }
 
             public int Livery { get; set; } = -1;
-
+            public byte HeadlightColor { get; set; } = 255;
             public byte RadioStation { get; set; } = 255;
             public string LicensePlate { get; set; }
 


### PR DESCRIPTION
This contains all the code required to sync Xenon headlight color over the network. Uses the Livery sync as sample code. Note that this does not fix the Xenon Headlight modkit issue, this will need to be fixed separately later.